### PR TITLE
Replace deprecated pypy3 with pypy-3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
     - python: 3.5
     - python: 2.7
     - python: pypy
-    - python: pypy3
+    - python: pypy-3.8
 
 install:
 - travis_retry pip install -r requirements.txt


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos